### PR TITLE
Don't assume the request URL is on port 80

### DIFF
--- a/src/PhabricatorClient/Client/CurlRequest.php
+++ b/src/PhabricatorClient/Client/CurlRequest.php
@@ -39,8 +39,7 @@ class CurlRequest {
 
         $this->setOption(CURLOPT_URL, $this->requestUrl)
              ->setOption(CURLOPT_VERBOSE, 0)
-             ->setOption(CURLOPT_HEADER, 0)
-             ->setOption(CURLOPT_PORT, 80);
+             ->setOption(CURLOPT_HEADER, 0);
     }
 
     /**


### PR DESCRIPTION
I had an issue where I couldn't call an API since it had SSL enabled. Removing the static port setting in cURL fixed this since SSL defaults to port 443.

Apologies for not doing this through your Phabricator setup. I have to wait to get my Phab account approved so I'm doing this here. Feel free to close this out.
