### PR TITLE
Fix incorrect setting of curl options

### DIFF
--- a/src/Client/Curl/CurlClient.php
+++ b/src/Client/Curl/CurlClient.php
@@ -78,7 +78,7 @@ class CurlClient implements ClientInterface {
      */
     protected function setOptionsOnRequest(CurlRequest $request, $options) {
         foreach($options as $option => $value) {
-            $request->setOption($options, $value);
+            $request->setOption($option, $value);
         }
     }
 


### PR DESCRIPTION
I was getting some array to string conversion errors in CurlRequest when setting some options for the CurlClient, as you can see it was assigning the whole array instead of the option key.